### PR TITLE
Add Circuit Python example for M0 board: Trinked M0 and Gemma M0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 Dave Hylands
+Copyright (c) 2017 David Glaude
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -30,16 +30,12 @@ for freq, msec in tune.notes()
     play_tone(freq, msec)
 ```
 
-When using a piezo you basically provide a 50% PWM signal to the piezo using the
-frequency of the note. Some piezo speakers can vary the volume by using a
-different duty cycle. The piezo on the G30DEV board I tested this on, it didn't
-seem to make any difference.
+When using a piezo you basically provide a 50% PWM signal to the piezo using the frequency of the note. Some piezo speakers can vary the volume by using a different duty cycle. The piezo on the G30DEV board Dave Hylands this on, it didn't seem to make any difference.
 
 In order to distinguish consequtive notes, you need a small gap between the notes.
-I chose to use 90% of the duration to play the tone, and 10% of duration to play
-silence.
+Dave Hylands chose to use 90% of the duration to play the tone, and 10% of duration to play silence.
 
-I used the following play_tone routine on the G30DEV board:
+Dave Hylands used the following play_tone routine on the G30DEV board:
 ```python
 import pyb
 buz_tim = pyb.Timer(3, freq=440)
@@ -54,7 +50,34 @@ def play_tone(freq, msec):
     pyb.delay(int(msec * 0.1))
 ```
 
-I put a recording of the above on YouTube: https://youtu.be/TadV2AEvfww
+Dave Hylands put a recording of the above on YouTube: https://youtu.be/TadV2AEvfww
 
 The G30DEV board definition files for MicroPython can be found here: https://github.com/dhylands/G30DEV
+
+David Glaude used the following play_tone routine on Circuit Python M0 board:
+```
+import board
+import pulseio
+import time
+
+speaker_pin   = board.D0  # Speaker is connected to this DIGITAL pin
+
+# Initialize input/output pins
+pwm       = pulseio.PWMOut(speaker_pin, variable_frequency=True, duty_cycle=0)
+
+def play_tone(freq, msec):
+#    print('freq = {:6.1f} msec = {:6.1f}'.format(freq, msec))
+    if freq > 0:
+        pwm.frequency  = int(freq)   # Set frequency
+        pwm.duty_cycle = 32767  # 50% duty cycle
+	time.sleep(msec*0.001)  # Play for a number of msec
+    pwm.duty_cycle = 0          # Stop playing
+    time.sleep(0.05)            # Delay 50 ms between notes
+```
+
+- circuit_test.py: Playing RTTTL on M0 Circuit Python board.
+- pc_test.py: Printing RTTTL decoding on any platform (no sound produced).
+- pyb_test.py: Playing RTTTL on G30DEV board.
+- rtttl.py: RTTTL decoding library.
+- songs.py: Optionnal collection of RTTTL songs to test the library.
 

--- a/circuit_test.py
+++ b/circuit_test.py
@@ -1,0 +1,26 @@
+from rtttl import RTTTL
+import songs
+
+import board
+import pulseio
+import time
+
+speaker_pin   = board.D0  # Speaker is connected to this DIGITAL pin
+
+# Initialize input/output pins
+pwm       = pulseio.PWMOut(speaker_pin, variable_frequency=True, duty_cycle=0)
+
+def play_tone(freq, msec):
+#    print('freq = {:6.1f} msec = {:6.1f}'.format(freq, msec))
+    if freq > 0:
+        pwm.frequency  = int(freq)   # Set frequency
+        pwm.duty_cycle = 32767  # 50% duty cycle
+	time.sleep(msec*0.001)  # Play for a number of msec
+    pwm.duty_cycle = 0          # Stop playing
+    time.sleep(0.05)            # Delay 50 ms between notes
+
+tune = RTTTL(songs.find('Entertainer'))
+
+for freq, msec in tune.notes():
+    play_tone(freq, msec)
+


### PR DESCRIPTION
Hi,

I reused your code to play RTTTL sound on Circuit Python M0 board.
Those board are not supported by Adafruit RTTTL library that use audioio (only available on Express board).
So my demo use pulseio that is available for those board since Circuit Python 2.1.

Feel free to use/merge this.

Regards