### PR TITLE
Add files to allow playing in Sonic Pi

### DIFF
--- a/ringtone.rb
+++ b/ringtone.rb
@@ -1,0 +1,38 @@
+#ringtone.rb
+#this script retrieves ringtone data using a python script
+#to create a .json format file containing two lists
+#'freqs' which contains a list of note frequencies
+#"durs which cotnains a correspending list of durations in msecs.
+#the file is loaded into SOnic Pi and teh two data lists extracted
+#they are then played using the chiplead synth
+#I've transposed the data down an octave in teh play command
+#conversion to sonic pi play format is easy using the buit in hz_to_midi command
+
+#the list of songs refers to those songs whose darta in in the songs.py file
+path= '/Users/rbn/src/upy-rtttl/' #path to python files adjust for your system.
+song_list=[ "Super Mario - Main Theme","Super Mario - Title Music","SMBtheme",
+            "SMBwater","SMBunderground","Picaxe","The Simpsons","Indiana","TakeOnMe",
+            "Entertainer","Muppets","Xfiles","Looney","20thCenFox","Bond","MASH",
+            "StarWars","GoodBad","TopGun","A-Team","Flinstones","Jeopardy",
+            "Gadget","Smurfs","MahnaMahna","LeisureSuit","MissionImp"]
+song_list.each do|name| #play each song in turn
+  
+  cmdtext='/usr/local/bin/python3 '+path+'sp_json.py -n "'+name+'"' #alter python3 binary location for your system.
+  
+  #typical system call to the python script below
+  #system('/usr/local/bin/python3 /Users/rbn/src/upy-rtttl/sp_json.py -n "SMBwater"')
+  system(cmdtext) #call the python script to generate .json file
+  sleep 0.5
+  require 'json'
+  file = File.read(path+'sptune.json')
+  data_hash = JSON.parse(file)
+  f= data_hash['freqs']
+  d=data_hash['durs']
+  use_bpm 60
+  puts "playing ringtone #{name}"
+  use_synth :chiplead
+  f.zip(d).each do |fr,dur|
+    play hz_to_midi(fr)-12,release: dur/1000.0 if fr>0 #transposed down an octave
+    sleep dur.to_f/1000
+  end
+end

--- a/sp_json.py
+++ b/sp_json.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+#outputs data for freqs and durations to a json format file
+#gets input data from name parameter -n supp;ied on command line
+#from song.py data file
+#eg ./sp_json.py -n Entertainer
+#output file intended to be read and used by Sonic Pi
+from rtttl import RTTTL
+import songs
+import json
+import argparse
+
+def getData(name):   
+    tune = RTTTL(songs.find(name))
+    n=[]
+    d=[]
+    for freq, msec in tune.notes():
+        n.append(freq)
+        d.append(msec)
+    data = {}
+    data['freqs']=n
+    data['durs']=d
+    with  open("/Users/rbn/src/upy-rtttl/sptune.json","w+") as outfile:
+        json.dump(data, outfile)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-n",default = 'Entertainer',help='name of tune')
+    args=parser.parse_args()
+    print(args.n)
+    getData(args.n)


### PR DESCRIPTION
You may care to add these two files. The python script produces an output data file in .json format from a named piece in the songs.py file.
The Sonic Pi file (which runs in Sonic Pi!) extracts the frequency and duration data from the .json file and then plays the ringtone.
There is a recording of three of them produced using these files at https://soundcloud.com/user-195236670/ringtones